### PR TITLE
PHP version & Guzzle client version updated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
   "repositories": [
   ],
   "require":      {
-    "php":                       ">=5.5.0",
+    "php":                       ">=7.2",
     "fernleafsystems/utilities": "^1.0",
-    "guzzlehttp/guzzle":         "^6.0"
+    "guzzlehttp/guzzle":         "^6.0|^7.0"
   },
   "require-dev":  {
   },


### PR DESCRIPTION
PHP 5 is outdated (https://en.wikipedia.org/wiki/PHP#PHP_5).

Can you please upgrade the dependencies. Thanks!